### PR TITLE
Lower PHP version requirement to 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php" : "^7.1"
+        "php" : "^7.0"
     },
     "require-dev": {
         "orchestra/testbench":"~3.8.0"


### PR DESCRIPTION
When working with your package, I noticed that it worked on PHP 7.0, yet it declared PHP 7.1 as the minimum version. This is a bit troublesome for us, since our servers are still on Ubuntu 16.04 and thus PHP 7.0.

By lowering the version requirement, people still on PHP 7.0 will be able to use this package without resorting to dirty composer.lock hacks or forking. Again, this package works completely fine on PHP 7.0.