### PR TITLE
add diffFromNow costume filter

### DIFF
--- a/src/BladeFilters.php
+++ b/src/BladeFilters.php
@@ -5,6 +5,7 @@ namespace Pine\BladeFilters;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Pine\BladeFilters\Exceptions\MissingBladeFilterException;
+use Carbon\Carbon;
 
 class BladeFilters
 {
@@ -114,5 +115,31 @@ class BladeFilters
     public static function reverse($value)
     {
         return strrev($value);
+    }
+    
+    /**
+     *  get difference between a datetime and current datetime.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function diffFromNow($value)
+    {
+        $diff = Carbon::now()->diffInSeconds($value);
+        if ($diff < 60) {
+            return round($diff) . 's ago';
+        }
+        
+        $diff = $diff / 60;
+        if ($diff < 60) {
+            return round($diff) . 'min ago';
+        }
+        
+        $diff = $diff / 60;
+        if ($diff < 60) {
+            return round($diff) . 'hours ago';
+        }
+           
+        return round($diff / 24) . ' days ago';
     }
 }

--- a/src/BladeFilters.php
+++ b/src/BladeFilters.php
@@ -125,21 +125,31 @@ class BladeFilters
      */
     public static function diffFromNow($value)
     {
-        $diff = Carbon::now()->diffInSeconds($value);
-        if ($diff < 60) {
-            return round($diff) . 's ago';
-        }
-        
-        $diff = $diff / 60;
-        if ($diff < 60) {
-            return round($diff) . 'min ago';
-        }
-        
-        $diff = $diff / 60;
-        if ($diff < 60) {
-            return round($diff) . 'hours ago';
-        }
-           
-        return round($diff / 24) . ' days ago';
+            $diff = Carbon::now()->diffInSeconds($value);
+            if ($diff < 60) {
+                return round($diff) . 's ago';
+            }
+
+            $diff = $diff / 60;
+            if ($diff < 60) {
+                return round($diff) . 'min ago';
+            }
+
+            $diff = $diff / 60;
+            if ($diff < 24) {
+                return round($diff) . 'hours ago';
+            }
+
+            $diff = $diff / 24;
+            if ($diff < 30) {
+                return round($diff) . 'days ago';
+            }
+
+            $diff = $diff / 30;
+            if ($diff < 12) {
+                return round($diff) . 'months ago';
+            }
+
+            return round($diff / 12) . ' years ago';
     }
 }


### PR DESCRIPTION
I write a costum filtre called **diffFromNow** to calculate the difference between a datetime and current datetime

```php
   /**
     *  get difference between a datetime and current datetime.
     *
     * @param  string  $value
     * @return string
     */
    public static function diffFromNow($value)
    {
            $diff = Carbon::now()->diffInSeconds($value);
            if ($diff < 60) {
                return round($diff) . 's ago';
            }

            $diff = $diff / 60;
            if ($diff < 60) {
                return round($diff) . 'min ago';
            }

            $diff = $diff / 60;
            if ($diff < 24) {
                return round($diff) . 'hours ago';
            }

            $diff = $diff / 24;
            if ($diff < 30) {
                return round($diff) . 'days ago';
            }

            $diff = $diff / 30;
            if ($diff < 12) {
                return round($diff) . 'months ago';
            }

            return round($diff / 12) . ' years ago';
    }

```